### PR TITLE
Patch thư viện cho testlib

### DIFF
--- a/.docker/tierlqdoj/Dockerfile
+++ b/.docker/tierlqdoj/Dockerfile
@@ -19,10 +19,13 @@ RUN mkdir /judge /problems && cd /judge && \
     runuser -u judge -w PATH -- /env/bin/dmoj-autoconf -V > /judge-runtime-paths.yml && \
     echo '  crt_x86_in_lib32: true' >> /judge-runtime-paths.yml && \
     curl -L https://raw.githubusercontent.com/MikeMirzayanov/testlib/master/testlib.h -o /usr/include/testlib.h && \
+    sed -i '/^#include <cstdio>/a#include <cstdint>' /usr/include/testlib.h && \
     g++ -std=c++17 -Wall -DONLINE_JUDGE -O2 -fmax-errors=5 -march=native -s /usr/include/testlib.h && \
     curl -L https://raw.githubusercontent.com/skyvn97/testlib/customized-testlib/testlib_themis_cms.h -o /usr/include/testlib_themis_cms.h && \
+    sed -i '/^#include <cstdio>/a#include <cstdint>' /usr/include/testlib_themis_cms.h && \
     g++ -std=c++17 -Wall -DONLINE_JUDGE -DTHEMIS -O2 -fmax-errors=5 -march=native -s /usr/include/testlib_themis_cms.h && \
     curl -L https://raw.githubusercontent.com/cuom1999/testlib/customized-testlib/testlib_modified.h -o /usr/include/testlib_modified.h && \
+    sed -i '/^#include <cstdio>/a#include <cstdint>' /usr/include/testlib_modified.h && \
     g++ -std=c++17 -Wall -DONLINE_JUDGE -DTHEMIS -O2 -fmax-errors=5 -march=native -s /usr/include/testlib_modified.h && \
     find /usr/include/ -name stdc++.h -exec g++ -std=c++17 -Wall -DONLINE_JUDGE -O2 -fmax-errors=5 -march=native -s {} \;
 


### PR DESCRIPTION
Với g++ mới nhất thì testlib.h bị thiếu <cstdio.h>, khi build container sẽ bị lỗi.